### PR TITLE
Add feature to prevent self-modification (get someone else to do it)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "totally-safe-transmute"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["Benjamin Herr <ben@0x539.de>"]
 edition = "2018"
 description = "I'm sure it's fine."
@@ -10,3 +10,6 @@ repository = "https://github.com/ben0x539/totally-safe-transmute"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[features]
+dd=[]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,27 +1,55 @@
 #![forbid(unsafe_code)]
 
-use std::{io::{self, Write, Seek}, fs};
-
+use std::{
+    fs,
+    io::{self, Seek, Write},
+    process,
+};
 pub fn totally_safe_transmute<T, U>(v: T) -> U {
     #[repr(C)]
     enum E<T, U> {
         T(T),
-        #[allow(dead_code)] U(U),
+        #[allow(dead_code)]
+        U(U),
     }
     let v = E::T(v);
 
-    let mut f = fs::OpenOptions::new()
-        .write(true)
-        .open("/proc/self/mem").expect("welp");
+    if cfg!(feature = "dd") {
+        let pid = process::id();
+        let cmdline = format!(
+            r#"echo -ne '\x01' | dd of="/proc/{}/mem" bs=1 conv=notrunc seek={} 2>/dev/null"#,
+            pid, &v as *const _ as u64
+        );
+        if process::Command::new("sh")
+            .arg("-c")
+            .arg(cmdline)
+            .status()
+            .expect("oh no")
+            .success()
+        {
+            match v {
+                E::T(_t) => panic!("broken"),
+                E::U(v) => return v,
+            }
+        } else {
+            panic!("noooo");
+        }
+    } else {
+        let mut f = fs::OpenOptions::new()
+            .write(true)
+            .open("/proc/self/mem")
+            .expect("welp");
 
-    f.seek(io::SeekFrom::Start(&v as *const _ as u64)).expect("oof");
-    f.write(&[1]).expect("darn");
+        f.seek(io::SeekFrom::Start(&v as *const _ as u64))
+            .expect("oof");
+        f.write(&[1]).expect("darn");
 
-    if let E::U(v) = v {
-        return v;
+        if let E::U(v) = v {
+            return v;
+        }
+
+        panic!("rip");
     }
-
-    panic!("rip");
 }
 
 #[test]


### PR DESCRIPTION
Linux lets processes modify the memory of other processes. The `dd` feature flag exposes this behavior.